### PR TITLE
Fixing Lore command missing super.getCommandParameters().

### DIFF
--- a/src/modules/commands/Lore/index.ts
+++ b/src/modules/commands/Lore/index.ts
@@ -16,10 +16,9 @@ class Lore extends AbstractCommand {
     public execute(message: Discord.Message): void {
         super.execute(message);
 
-        const commandStr = message.content.split(constants.COMMAND_PREFIX)[1];
-        const parameters = commandStr.split(" ");
+        const commandParameters = super.getCommandParameters();
 
-        switch (parameters[1]) {
+        switch (commandParameters[1]) {
             case "add":
                 LoreService.addLore(message);
                 break;


### PR DESCRIPTION
Small fix for the Lore command. The Lore command was still using the old way of getting command parameters. It now uses the AbstractCommand getCommandParameters function.