### PR TITLE
Clean up import paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 // Imports
 import * as Discord from "discord.js";
-import chalk from "chalk";
-import constants from "./modules/constants";
-import Logger from "./modules/io/Logger";
+import constants from "modules/constants";
+import Logger from "modules/io/Logger";
 
-import MessageHandler from "./modules/handlers/message";
+import MessageHandler from "modules/handlers/message";
 
 // Create client interface and prepare handler
 const client = new Discord.Client();

--- a/src/models/AbstractCommand.ts
+++ b/src/models/AbstractCommand.ts
@@ -1,7 +1,7 @@
 import Discord from "discord.js";
-import CommandInterface from "./CommandInterface";
-import Logger from "../modules/io/Logger";
-import constants from "../modules/constants";
+import CommandInterface from "models/CommandInterface";
+import Logger from "modules/io/Logger";
+import constants from "modules/constants";
 
 class AbstractCommand implements CommandInterface {
     public name = "command";

--- a/src/modules/commands/Help/Service/HelpService.ts
+++ b/src/modules/commands/Help/Service/HelpService.ts
@@ -1,5 +1,5 @@
 import Discord from "discord.js";
-import * as FileHelper from "../../../io/FileHelper";
+import * as FileHelper from "modules/io/FileHelper";
 
 class HelpService {
     private helpMessage = FileHelper.readTextFileContent("assets/text/help/message.txt");

--- a/src/modules/commands/Help/index.ts
+++ b/src/modules/commands/Help/index.ts
@@ -1,6 +1,6 @@
 import * as Discord from "discord.js";
-import AbstractCommand from "../../../models/AbstractCommand";
-import HelpService from "./Service/HelpService";
+import AbstractCommand from "models/AbstractCommand";
+import HelpService from "modules/commands/Help/Service/HelpService";
 
 class Help extends AbstractCommand {
     public name = "help";

--- a/src/modules/commands/Lore/Service/LoreService.ts
+++ b/src/modules/commands/Lore/Service/LoreService.ts
@@ -1,10 +1,10 @@
 import Discord from "discord.js";
 import fs from "fs";
-import * as FileHelper from "../../../io/FileHelper";
-import LoreHelper from "../Helper/LoreHelper";
+import * as FileHelper from "modules/io/FileHelper";
+import LoreHelper from "modules/commands/Lore/Helper/LoreHelper";
 import Path from "path";
-import settings from "../../../../settings.json";
-import Logger from "../../../io/Logger";
+import settings from "settings.json";
+import Logger from "modules/io/Logger";
 
 /**
  * TODO: Feature multiple lore files through filename parameter

--- a/src/modules/commands/Lore/index.ts
+++ b/src/modules/commands/Lore/index.ts
@@ -1,7 +1,6 @@
 import * as Discord from "discord.js";
-import constants from "../../constants";
-import AbstractCommand from "../../../models/AbstractCommand";
-import LoreService from "./Service/LoreService";
+import AbstractCommand from "models/AbstractCommand";
+import LoreService from "modules/commands/Lore/Service/LoreService";
 
 class Lore extends AbstractCommand {
     public name = "lore";

--- a/src/modules/commands/Poll/index.ts
+++ b/src/modules/commands/Poll/index.ts
@@ -1,5 +1,5 @@
 import * as Discord from "discord.js";
-import AbstractCommand from "../../../models/AbstractCommand";
+import AbstractCommand from "models/AbstractCommand";
 
 class Poll extends AbstractCommand {
     public name = "poll";

--- a/src/modules/commands/React/Service/ReactService.ts
+++ b/src/modules/commands/React/Service/ReactService.ts
@@ -1,9 +1,9 @@
 import Discord from "discord.js";
 import fs from "fs";
-import * as FileHelper from "../../../io/FileHelper";
-import constants from "../../../constants";
+import * as FileHelper from "modules/io/FileHelper";
+import constants from "modules/constants";
 import Path from "path";
-import settings from "../../../../settings.json";
+import settings from "settings.json";
 
 class ReactService {
     private reactImgFolder = "./assets/img/reaction/";

--- a/src/modules/commands/React/index.ts
+++ b/src/modules/commands/React/index.ts
@@ -1,6 +1,6 @@
 import * as Discord from "discord.js";
 import ReactService from "./Service/ReactService";
-import AbstractCommand from "../../../models/AbstractCommand";
+import AbstractCommand from "models/AbstractCommand";
 
 class React extends AbstractCommand {
     public name = "react";

--- a/src/modules/commands/index.ts
+++ b/src/modules/commands/index.ts
@@ -1,9 +1,9 @@
-import CommandInterface from "../../models/CommandInterface";
+import CommandInterface from "models/CommandInterface";
 
-import Help from "./Help";
-import React from "./React";
-import Poll from "./Poll";
-import Lore from "./Lore";
+import Help from "modules/commands/Help";
+import React from "modules/commands/React";
+import Poll from "modules/commands/Poll";
+import Lore from "modules/commands/Lore";
 
 let HelpCommand = new Help();
 let ReactCommand = new React();

--- a/src/modules/constants/index.ts
+++ b/src/modules/constants/index.ts
@@ -1,4 +1,4 @@
 // More information on how to export using the module syntax
 // https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export
 
-export { default } from "./env";
+export { default } from "modules/constants/env";

--- a/src/modules/handlers/command.ts
+++ b/src/modules/handlers/command.ts
@@ -1,7 +1,7 @@
 import * as Discord from "discord.js";
 
-import commands from "../commands";
-import constants from "../constants";
+import commands from "modules/commands";
+import constants from "modules/constants";
 
 /**
  * Handler for commands. Used in the MessageHandler.

--- a/src/modules/handlers/message.ts
+++ b/src/modules/handlers/message.ts
@@ -1,7 +1,7 @@
 import * as Discord from "discord.js";
 
-import CommandHandler from "./command";
-import constants from "../constants";
+import CommandHandler from "modules/handlers/command";
+import constants from "modules/constants";
 
 /**
  * Handler for messages. Used on Discord.Client "message" events.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    "baseUrl": "src",                          /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
Cleaned up import paths to use absolute paths instead of relative paths. All imports now originate from the `src/` folder.